### PR TITLE
Added usage clarification for Kotlin users

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ public class GizmoTest {
 
 ```
 
+#### Note for Kotlin/JUnit 5 Users
+To allow the extension to pick-up your Collector, the property must be annotated so reflection works correctly:
+```kotlin
+    @JvmField
+    val collector = JUnit5LogCollector(logger)
+```
+See: https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#instance-fields
+
 ### TestNG
 ```java
 @Test


### PR DESCRIPTION
I tried using this library on a Kotlin project and for some reason the reflection in JUnit5LogCollectorExtension never picked up my Collector.  The reason is that the fields returned from 'declaredFields' on the class were all marked as private and 'publicFields' was empty, even if I explicitly declared the property as public.
It looks like it is due to extra work Kotlin does behind the scenes when dealing with properties, as per:  https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#instance-fields
Adding that annotation made everything work as expected.

I've updated the docs to mention this, and I've only tested it with JUnit 5, but it appears that is the only place reflection is used anyway.
Hopefully this is useful - feel free to reword as you see fit.
Thanks!