### PR TITLE
adding generics to avoid casting the getRawLogs()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ The following examples show how to add the framework to a test, provide it with 
 Logger logger = LogManager.getLogger("acme.Gizmo");
 
 @Rule
-public JUnit4LogCollector collector = new JUnit4LogCollector(logger);
+public JUnit4LogCollector<LogEvent> collector = new JUnit4LogCollector<>(logger);
 
 @Test
 public void testGizmo() {
     Gizmo gizmo = new Gizmo();
     gizmo.run();
 
-    List<LogEvent> rawLogs = (List<LogEvent>) collector.getRawLogs();
+    List<LogEvent> rawLogs = collector.getRawLogs();
     assertTrue(rawLogs.stream().noneMatch(l -> l.getLevel() == Level.ERROR));
 }
 ```
@@ -57,14 +57,14 @@ public void testGizmo() {
 public class GizmoTest {
     Logger logger = LogManager.getLogger("acme.Gizmo");
 
-    JUnit5LogCollector collector = new JUnit5LogCollector(logger);
+    JUnit5LogCollector<LogEvent> collector = new JUnit5LogCollector<>(logger);
 
     @Test
     void testGizmo() {
         Gizmo gizmo = new Gizmo();
         gizmo.run();
 
-        List<LogEvent> rawLogs = (List<LogEvent>) collector.getRawLogs();
+        List<LogEvent> rawLogs = collector.getRawLogs();
         assertTrue(rawLogs.stream().noneMatch(l -> l.getLevel() == Level.ERROR));
     }
 }
@@ -96,7 +96,7 @@ public class GizmoTest {
         Gizmo gizmo = new Gizmo();
         gizmo.run();
 
-        List<LogEvent> rawLogs = (List<LogEvent>) TestNGLogCollector.getRawLogs();
+        List<LogEvent> rawLogs = TestNGLogCollector.getRawLogs(LoggingEvent.class);
         assertTrue(rawLogs.stream().noneMatch(l -> l.getLevel() == Level.ERROR));
     }
 }
@@ -127,6 +127,5 @@ testCompile 'dk.bitcraft:LogCollector:0.9.0'
   - Come up with a better name for the framework.
   - Improve Javadoc and documentation.
   - Discover the intricacies of the various logging frameworks in real-world settings and adapt to them.
-  - Avoid the ugly cast in `getRawLogs`.
   - Detect SLF4j's `NOPLogger` and replace it with `SimpleLogger`
   - Any ideas? Get in touch!

--- a/src/main/java/dk/bitcraft/lc/CollectorImpl.java
+++ b/src/main/java/dk/bitcraft/lc/CollectorImpl.java
@@ -2,9 +2,9 @@ package dk.bitcraft.lc;
 
 import java.util.List;
 
-interface CollectorImpl {
+interface CollectorImpl<LOG> {
     void setup();
     void remove();
     List<String> getResult();
-    List<?> getRawLogs();
+    List<LOG> getRawLogs();
 }

--- a/src/main/java/dk/bitcraft/lc/JUnit4LogCollector.java
+++ b/src/main/java/dk/bitcraft/lc/JUnit4LogCollector.java
@@ -7,9 +7,10 @@ import java.util.List;
 import java.util.Optional;
 
 
-public class JUnit4LogCollector extends ExternalResource {
-    private CollectorImpl collector;
+public class JUnit4LogCollector<LOG> extends ExternalResource {
+    private CollectorImpl<LOG> collector;
 
+    @SuppressWarnings("unchecked")
     public JUnit4LogCollector(Object logger) {
         collector = Arrays.stream(Frameworks.values())
                 .map(v -> v.getCollector(logger))
@@ -33,7 +34,7 @@ public class JUnit4LogCollector extends ExternalResource {
         return collector.getResult();
     }
 
-    public List<?> getRawLogs() {
+    public List<LOG> getRawLogs() {
         return collector.getRawLogs();
     }
 }

--- a/src/main/java/dk/bitcraft/lc/JUnit5LogCollector.java
+++ b/src/main/java/dk/bitcraft/lc/JUnit5LogCollector.java
@@ -4,9 +4,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-public class JUnit5LogCollector {
-    private CollectorImpl collector;
+public class JUnit5LogCollector<LOG> {
+    private CollectorImpl<LOG> collector;
 
+    @SuppressWarnings("unchecked")
     public JUnit5LogCollector(Object logger) {
         collector = Arrays.stream(Frameworks.values())
                 .map(v -> v.getCollector(logger))
@@ -28,7 +29,7 @@ public class JUnit5LogCollector {
         return collector.getResult();
     }
 
-    public List<?> getRawLogs() {
+    public List<LOG> getRawLogs() {
         return collector.getRawLogs();
     }
 }

--- a/src/main/java/dk/bitcraft/lc/JavaUtilLoggingCollector.java
+++ b/src/main/java/dk/bitcraft/lc/JavaUtilLoggingCollector.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 
-public class JavaUtilLoggingCollector implements CollectorImpl {
+public class JavaUtilLoggingCollector implements CollectorImpl<LogRecord> {
 
     private final Logger logger;
     private ListHandler handler;
@@ -39,7 +39,7 @@ public class JavaUtilLoggingCollector implements CollectorImpl {
     }
 
     @Override
-    public List<?> getRawLogs() {
+    public List<LogRecord> getRawLogs() {
         return handler.records.stream().collect(toList());
     }
 

--- a/src/main/java/dk/bitcraft/lc/Log4j2Collector.java
+++ b/src/main/java/dk/bitcraft/lc/Log4j2Collector.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 import static java.util.stream.Collectors.toList;
 
-class Log4j2Collector implements CollectorImpl {
+class Log4j2Collector implements CollectorImpl<LogEvent> {
     private final Logger logger;
     ListAppender appender;
 
@@ -48,7 +48,7 @@ class Log4j2Collector implements CollectorImpl {
     }
 
     @Override
-    public List<?> getRawLogs() {
+    public List<LogEvent> getRawLogs() {
         return appender.events.stream().collect(toList());
     }
 

--- a/src/main/java/dk/bitcraft/lc/LogBackCollector.java
+++ b/src/main/java/dk/bitcraft/lc/LogBackCollector.java
@@ -2,7 +2,6 @@ package dk.bitcraft.lc;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -10,7 +9,7 @@ import ch.qos.logback.core.read.ListAppender;
 
 import static java.util.stream.Collectors.toList;
 
-class LogBackCollector implements CollectorImpl {
+class LogBackCollector implements CollectorImpl<ILoggingEvent> {
     private final Logger logger;
 
     private final static String appenderName = UUID.randomUUID().toString();
@@ -41,7 +40,7 @@ class LogBackCollector implements CollectorImpl {
     }
 
     @Override
-    public List<?> getRawLogs() {
+    public List<ILoggingEvent> getRawLogs() {
         return appender.list.stream().collect(toList());
     }
 }

--- a/src/main/java/dk/bitcraft/lc/SLF4JSimpleCollector.java
+++ b/src/main/java/dk/bitcraft/lc/SLF4JSimpleCollector.java
@@ -12,7 +12,7 @@ import static java.util.stream.Collectors.toList;
  * <p>SLF4J's SimpleLogger works by printing directly to System.err, so this collector assumes control of System.err and captures its output.</p>
  * <p>Any other usage of <code>System.err</code> will be included among the captured log statements.</p>
  */
-public class SLF4JSimpleCollector implements CollectorImpl {
+public class SLF4JSimpleCollector implements CollectorImpl<String> {
 
     private PrintStream systemErr;
     private CapturingPrintStream capturingPrintStream;
@@ -38,7 +38,7 @@ public class SLF4JSimpleCollector implements CollectorImpl {
     }
 
     @Override
-    public List<?> getRawLogs() {
+    public List<String> getRawLogs() {
         return getResult();
     }
 

--- a/src/main/java/dk/bitcraft/lc/TestNGLogCollector.java
+++ b/src/main/java/dk/bitcraft/lc/TestNGLogCollector.java
@@ -41,7 +41,7 @@ public class TestNGLogCollector implements ITestListener {
         return collector.getResult();
     }
 
-    public static List<?> getRawLogs() {
+    public static <LOG> List<LOG> getRawLogs(Class<LOG> clazz) {
         return collector.getRawLogs();
     }
 

--- a/src/test/java/dk/bitcraft/lc/JavaUtilLoggingTest.java
+++ b/src/test/java/dk/bitcraft/lc/JavaUtilLoggingTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertTrue;
 
 public class JavaUtilLoggingTest {
     @Rule
-    public JUnit4LogCollector collector = new JUnit4LogCollector(Logger.getLogger("test.logger"));
+    public JUnit4LogCollector<LogRecord> collector = new JUnit4LogCollector<>(Logger.getLogger("test.logger"));
 
     @Test
     public void test() {
@@ -29,7 +29,7 @@ public class JavaUtilLoggingTest {
         assertThat(logs.get(0)).contains("This is an warning!");
         assertThat(logs.get(1)).contains("This is another warning!");
 
-        List<LogRecord> rawLogs = (List<LogRecord>) collector.getRawLogs();
+        List<LogRecord> rawLogs = collector.getRawLogs();
         assertTrue(rawLogs.stream().allMatch(e -> e.getLevel() == Level.WARNING));
     }
 }

--- a/src/test/java/dk/bitcraft/lc/Log4j2Test.java
+++ b/src/test/java/dk/bitcraft/lc/Log4j2Test.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertTrue;
 
 public class Log4j2Test {
     @Rule
-    public JUnit4LogCollector collector = new JUnit4LogCollector(LogManager.getLogger("test.logger"));
+    public JUnit4LogCollector<LogEvent> collector = new JUnit4LogCollector<>(LogManager.getLogger("test.logger"));
 
     @Test
     public void test() {
@@ -28,7 +28,7 @@ public class Log4j2Test {
         assertThat(collector.getLogs()).hasSize(3)
                 .contains("This is an error!", "This is another error!", "This is a third error!");
 
-        List<LogEvent> rawLogs = (List<LogEvent>) collector.getRawLogs();
+        List<LogEvent> rawLogs = collector.getRawLogs();
         assertThat(rawLogs).hasSize(3);
 
         assertTrue(rawLogs.stream().allMatch(l -> l.getLevel() == Level.ERROR));

--- a/src/test/java/dk/bitcraft/lc/LogbackTest.java
+++ b/src/test/java/dk/bitcraft/lc/LogbackTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertTrue;
 
 public class LogbackTest {
     @Rule
-    public JUnit4LogCollector collector = new JUnit4LogCollector(LoggerFactory.getLogger("test.logger"));
+    public JUnit4LogCollector<LoggingEvent> collector = new JUnit4LogCollector<>(LoggerFactory.getLogger("test.logger"));
 
     @Test
     public void test() {
@@ -32,7 +32,7 @@ public class LogbackTest {
         assertThat(collector.getLogs()).hasSize(1);
         assertThat(collector.getLogs().get(0)).contains("This should be collected!");
 
-        List<LoggingEvent> rawLogs = (List<LoggingEvent>) collector.getRawLogs();
+        List<LoggingEvent> rawLogs = collector.getRawLogs();
         assertTrue(rawLogs.stream().allMatch(e -> e.getLevel() == Level.WARN));
     }
 }

--- a/test-environments/slf4j/src/test/java/test/RuleTest.java
+++ b/test-environments/slf4j/src/test/java/test/RuleTest.java
@@ -13,7 +13,7 @@ public class RuleTest {
     final static Logger logger = LoggerFactory.getLogger(RuleTest.class);
 
     @Rule
-    public JUnit4LogCollector collector = new JUnit4LogCollector(logger);
+    public JUnit4LogCollector<String> collector = new JUnit4LogCollector<>(logger);
 
 
     @Test

--- a/test-environments/testng/src/test/java/dk/bitcraft/lc/testng/PercentageTest.java
+++ b/test-environments/testng/src/test/java/dk/bitcraft/lc/testng/PercentageTest.java
@@ -32,7 +32,7 @@ public class PercentageTest {
         log.warn("This is a warning.");
         log.info("This is purely informational.");
 
-        List<LoggingEvent> logs = (List<LoggingEvent>) TestNGLogCollector.getRawLogs();
+        List<LoggingEvent> logs = TestNGLogCollector.getRawLogs(LoggingEvent.class);
 
         assertThat(logs)
                 .hasSize(2)


### PR DESCRIPTION
I've seen your comment "Avoid the ugly cast in `getRawLogs`" in the readme. This is a try to avoid this cast using generics. 

Let me know what you think. If you think is not useful or the wrong direction, feel free to close the PR.